### PR TITLE
GHA: upgrade actions/checkout to v4.1.1

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt install pari-gp
 
       - name: 'Checkout code'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: 'Run tests'
         run: |


### PR DESCRIPTION
To move away from the deprecated node 12.